### PR TITLE
Fix various typos

### DIFF
--- a/Doc.py
+++ b/Doc.py
@@ -55,7 +55,7 @@ class ModelDoc(object):
     * *Anchor* (str):
        The generated Markdown anchor for the documentation element.
        It is of the form "MODULE--CLASS--FUNCTION", where the module/class/function names
-       have underscores converted to hypen.
+       have underscores converted to hyphen.
     * *Number* (str):
        The Table of contents number as a string.  '#" for classes and "#.#" for functions.
 
@@ -178,7 +178,7 @@ class ModelFunction(ModelDoc):
 
     # ModelFunction.documentation_lines():
     def documentation_lines(self, class_name: str, prefix: str) -> Tuple[str, ...]:
-        """Return the ModelModule documentaion lines.
+        """Return the ModelModule documentation lines.
 
         Arguments:
         * *prefix* (str): The prefix to use to make the markdown work.
@@ -220,7 +220,7 @@ class ModelClass(ModelDoc):
         if hasattr(self.Class, "__doc__"):
             self.set_lines(cast(str, getattr(self.Class, "__doc__")))
 
-        # Set the Funcions attribute:
+        # Set the Functions attribute:
         model_functions: List[ModelFunction] = []
         attribute_name: str
         attribute: Any
@@ -254,7 +254,7 @@ class ModelClass(ModelDoc):
 
     # ModelClass.documentation_lines():
     def documentation_lines(self, prefix: str) -> Tuple[str, ...]:
-        """Return the ModelModule documentaion lines."""
+        """Return the ModelModule documentation lines."""
         lines: Tuple[str, ...] = self.Lines
         doc_lines: List[str] = [
             f"{prefix} <a name=\"{self.Anchor}\"></a>{self.Number} Class {self.Name}:",
@@ -305,7 +305,7 @@ class ModelModule(ModelDoc):
                     first_line = first_line[colon_index + 2:]  # Skip over "...: "
                     self.Lines = (first_line,) + self.Lines[1:]
 
-        # The Python import statment can import class to the module namespace.
+        # The Python import statement can import class to the module namespace.
         # We are only interested in classes that are defined in *module*:
         model_classes: List[ModelClass] = []
         class_type: type = type(ModelDoc)  # Any class name to get the associated class type.
@@ -361,7 +361,7 @@ class ModelModule(ModelDoc):
 
     # ModelModule.documentation_lines():
     def documentation_lines(self, prefix: str) -> Tuple[str, ...]:
-        """Return the ModelModule documentaion lines."""
+        """Return the ModelModule documentation lines."""
         # lines: Tuple[str, ...]  = self.Lines
         # doc_lines: List[str] = [f"{prefix} <a name=\"{self.Anchor}\"></a>{lines[0]}", ""]
         # doc_lines.extend(lines[1:])
@@ -466,7 +466,7 @@ def main() -> int:
 
     arguments: Tuple[str, ...] = tuple(sys.argv[1:])
     if "--unit-test" in arguments:
-        # For now hand provide the list of files to generte documenation for.:
+        # For now hand provide the list of files to generte documentation for.:
         arguments = ("Doc.py", "FabBOM.py", "FabGeometries.py", "FabJoins.py", "FabNodes.py",
                      "FabProjects.py", "FabShops.py", "FabSolids.py", "FabTools.py",
                      "FabUtilities.py", "TarSync.py", "Test.py", "__init__.py")

--- a/Embed.py
+++ b/Embed.py
@@ -87,7 +87,7 @@ and point the editor at the `.py` file.
 
 Another note is that neither the FreeCAD application nor the FreeCAD console
 (see section immediately below) honor the `PYTHONPATH` environment variable.
-This is deliberate and ensures that is the exact same Python environment is alway used
+This is deliberate and ensures that is the exact same Python environment is always used
 and that it is not effected by other Python applications that require PYTHONPATH
 modifications to properly operate.
 The workaround is add code to explicitly modify `sys.path` as discussed a bit further below.
@@ -196,7 +196,7 @@ The following piece of code will exit the window system when the GUI is up:
      if App.GuiUp:
          Gui.getMainWindow().close()
 
-When the python version changes the followning packages need to be intalled:
+When the python version changes the followning packages need to be installed:
 
 
 

--- a/FabCNC.py
+++ b/FabCNC.py
@@ -32,7 +32,7 @@ environment variable for just one execution of the freecad19 python interpreter 
 # cp -r ~/.local/lib/python3.8/site-packages/pudb ./squashfs-root/usr/lib/python3.8/site-packages/
 # ```
 # To enable `pudb`, uncomment `import pudb` and `pudb.start()`:
-# TODO: Replace `/home/wayne` imediately below and in the first line of this file.
+# TODO: Replace `/home/wayne` immediately below and in the first line of this file.
 SHARP_EXEC_PATH = "/home/wayne/public_html/projects/Fab/squashfs-root/usr/bin/python"
 import sys
 if sys.executable == SHARP_EXEC_PATH:
@@ -81,7 +81,7 @@ _ = PathPocket  # TODO: remove
 
 
 # This causes out flake8 to think App are defined.
-# It is actually present in the FreeCAD Python exectution envriorment.
+# It is actually present in the FreeCAD Python execution envriorment.
 App: Any
 if False:
     App = None
@@ -367,7 +367,7 @@ class FabCQtoFC(object):
                 append_documentation(pocket, out_file, "Pocket")
                 append_documentation(drilling, out_file, "Drilling")
 
-            # Remove the temporary opration objects:
+            # Remove the temporary operation objects:
             project_document: Any = self.ProjectDocument
             project_document.removeObject("IgnoreThisProfile")
             project_document.removeObject("IgnoreThisPocket")
@@ -379,7 +379,7 @@ class FabCQtoFC(object):
             pocket_infos: Set[str] = set(self.get_pocket_infos().keys())
             drilling_infos: Set[str] = set(self.get_drilling_infos().keys())
 
-            match("commmon", commons, common_infos)
+            match("common", commons, common_infos)
             match("pocket", pockets, pocket_infos)
             match("profile", profiles, extrude_infos)
             match("drilling", drillings, drilling_infos)
@@ -592,7 +592,7 @@ class FabCQtoFC(object):
             print(message)
             assert False, message
 
-        # Recursively process any *chidren* JSON nodes:
+        # Recursively process any *children* JSON nodes:
         if "children" in json_dict:
             children = cast(List[Dict[str, Any]],
                             self.key_verify("children", json_dict, list, tree_path, "Children"))
@@ -1029,7 +1029,7 @@ class FabCQtoFC(object):
         if indent:
             print(f"{indent} StepFile: {step_file}")
 
-        # This code currently trys to work with object in a seperate *steps_document* and
+        # This code currently tries to work with object in a separate *steps_document* and
         # the main *project_document*.  Change the conditional to switch between.
         use_project_document: bool = True
         document: Any = self.ProjectDocument if use_project_document else self.StepsDocument
@@ -1042,7 +1042,7 @@ class FabCQtoFC(object):
         step_object: Any = document.RootObjects[before_size]
         step_object.Label = label
 
-        # When the STEP files are colocated with the assemblies and such, the visibiliy
+        # When the STEP files are colocated with the assemblies and such, the visibility
         # of the associated *gui_step_object* needs to be disabled.
         if use_project_document and App.GuiUp:  # type: ignore
             gui_document: Any = Gui.getDocument(document.Label)  # type: ignore

--- a/FabGeometries.py
+++ b/FabGeometries.py
@@ -233,7 +233,7 @@ class Fab_Plane(object):
         #   OCP.Standard.Standard_ConstructionError: gp_GTrsf::Trsf() - non-orthogonal GTrsf
         # on matrices that are clearly orthogonal (i.e. M * Mt = I, where Mt is the M transpose.)
         # As a work around, skip cq.Vector and cq.Matrix, create the 3x3 rotation coefficients,
-        # and manually, do the point (1x3) by roatation matrix (3x3) and get the rotated
+        # and manually, do the point (1x3) by rotation matrix (3x3) and get the rotated
         # point (1x3).
         #
         # matrix: cq.Matrix = cq.Matrix([
@@ -882,7 +882,7 @@ class FabCircle(FabGeometry):
         """Return a new FabCircle projected onto a plane.
 
         Arguments:
-        * *plane* (Fab_Plane): Plane to proejct to.
+        * *plane* (Fab_Plane): Plane to project to.
 
         Returns:
         * (FabCircle): The newly projected FabCicle.
@@ -946,10 +946,10 @@ class FabPolygon(FabGeometry):
 
     A FabPolygon is represented as a sequence of corners (i.e. a Vector) where each corner can
     optionally be filleted with a radius.  In order to make it easier to use, a corner can be
-    specified as simple Vector or as a tuple that specifes a Vector and a radius.  The radius
+    specified as simple Vector or as a tuple that specifies a Vector and a radius.  The radius
     is in millimeters and can be provided as either Python int or float.  When an explicit
     fillet radius is not specified, higher levels in the software stack will typically substitute
-    in a deburr radius for external corners and an interal tool radius for internal corners.
+    in a deburr radius for external corners and an internal tool radius for internal corners.
     FabPolygon's are frozen and can not be modified after creation.
 
     Example:
@@ -1051,7 +1051,7 @@ class FabPolygon(FabGeometry):
 
     # FabPolygon.project_to_plane():
     def project_to_plane(self, plane: Fab_Plane, tracing: str = "") -> "FabPolygon":
-        """Return nre FabPolygon prejected onto a plane.
+        """Return nre FabPolygon projected onto a plane.
 
         Arguments:
         * *plane* (Fab_Plane): The plane to project onto.

--- a/FabNodes.py
+++ b/FabNodes.py
@@ -29,7 +29,7 @@ Two notable attributes of the FabNode are:
    Up is frequently used in code to access other FabNode's higher in the FabNode tree.
 * *Project* (FabNode):
    The FabNode tree root and is always of type FabProject which is defined in Project package.
-   Due to the Python lanaguage disallowal of circular `import` statements, this is returned
+   Due to the Python language disallowal of circular `import` statements, this is returned
    as type FabNode rather than type FabProject.
 See the FabNode documentation for further attributes.
 
@@ -716,7 +716,7 @@ class FabBox(object):
         assert check(box.DT, 0, 0, 3), "DT"
         assert check(box.DW, -1, 0, 0), "DW"
 
-        # Test FabBox() contructors:
+        # Test FabBox() constructors:
         tne: Vector = Vector(1, 2, 3)
         bsw: Vector = Vector(-1, -2, -3)
         new_box: FabBox = FabBox()
@@ -745,7 +745,7 @@ class Fab_Steps(object):
     has value associated with the .step file contents.
 
     There are three operations:
-    * Fab_Steps(): This is the initalizer.
+    * Fab_Steps(): This is the initializer.
     * activate(): This method is used to activate a .stp file for reading and/or writing.
     * flush_stales(): This method is used to remove previous .stp files that are now longer used.
 
@@ -898,7 +898,7 @@ class Fab_ProduceState(object):
     * *StepsDirectory* (Path):
       The path to the directory to store STEP (`.stp`) files into.
     * *Steps* (Fab_Steps):
-      The step file directory managment object.
+      The step file directory management object.
     * *ObjectsTable* (Dict[str, Any]):
       A table of objects that can be accessed via a debugger.
     * *ToolControllersTable*: (Dict[FabToolController, int]):
@@ -906,7 +906,7 @@ class Fab_ProduceState(object):
     * *OperationIndex* (int):
       An index for the current operation being performed for a mount.
 
-    This class is for interal use only:
+    This class is for internal use only:
     """
 
     StepsDirectory: Path
@@ -1177,7 +1177,7 @@ class FabNode(FabBox):
     def probe(self, label: str) -> None:
         """Perform a probe operation.
 
-        This method can be overriden and called to perform debug probes.
+        This method can be overridden and called to perform debug probes.
         """
         root: FabNode = self._Project
         if not hasattr(root, "probe"):

--- a/FabProjects.py
+++ b/FabProjects.py
@@ -112,7 +112,7 @@ class FabAssembly(Fab_Group):
 
     # FabAssembly.post_produce1():
     def post_produce1(self, produce_state: Fab_ProduceState, tracing: str = "") -> None:
-        """Preform FabAssembly phase1 post production."""
+        """Perform FabAssembly phase1 post production."""
         tracing = self.Tracing  # Ignore *tracing* argument.
         if tracing:
             print(f"{tracing}=>FabAssembly({self.Label}).post_produce1(*, *)")
@@ -188,7 +188,7 @@ class FabDocument(FabNode):
         self._AppDocument = None
         self._GuiDocument = None
 
-        # Verfiy *suffix*;
+        # Verify *suffix*;
         if not isinstance(self.FilePath, Path):
             raise RuntimeError(f"{self.FullPath}: '{self.FilePath}' is not a Path")
         suffix: str = self.FilePath.suffix

--- a/FabShops.py
+++ b/FabShops.py
@@ -21,7 +21,7 @@ from cadquery import Vector  # type: ignore
 # <--------------------------------------- 100 characters ---------------------------------------> #
 
 # Issues:
-# * Turn off Legacy tools Path => Preferrences => [] Enable Legacy Tools
+# * Turn off Legacy tools Path => Preferences => [] Enable Legacy Tools
 # * Edit move the from line 11 to line 10 in .../Tools/Bit/45degree_chamfer.fctb to fix JSON error.
 # * When setting path to library, be sure to include .../Tools/Library  (one level up does not work)
 
@@ -38,18 +38,18 @@ class FabSpindle(object):
     Attributes:
     * *Type* (str): Spindle Type (e.g. "R8", "Cat40", etc.)
     * *Speed* (int): Maximum spindle speed in rotations per minute.
-    * *Reversable* (bool): True if spindle can be reversed.
+    * *Reversible* (bool): True if spindle can be reversed.
     * *FloodCooling* (bool): True if flood cooling is available.
     * *MistCooling* (bool): True if mist coooling is available.
 
     Constructor:
-    * FabSpindle("Type", Speed, Reversable, FloodCooling, MistCooling)
+    * FabSpindle("Type", Speed, Reversible, FloodCooling, MistCooling)
 
     """
 
     Type: str
     Speed: int
-    Reversable: bool
+    Reversible: bool
     FloodCooling: bool
     MistCooling: bool
 
@@ -58,7 +58,7 @@ class FabSpindle(object):
         """Finish initializing the FabSpindle."""
         check_type("FabSpindle.Type", self.Type, str)
         check_type("FabSpindle.Speed", self.Speed, int)
-        check_type("FabSpindle.Reversable", self.Reversable, bool)
+        check_type("FabSpindle.Reversible", self.Reversible, bool)
         check_type("FabSpindle.FloodCooling", self.FloodCooling, bool)
         check_type("FabSpindle.MistCooling", self.MistCooling, bool)
 
@@ -70,7 +70,7 @@ class FabSpindle(object):
         spindle: FabSpindle = FabSpindle("R8", 5000, True, True, False)
         assert spindle.Type == "R8", spindle.Type
         assert spindle.Speed == 5000, spindle.Speed
-        assert spindle.Reversable, spindle.Reversable
+        assert spindle.Reversible, spindle.Reversible
         assert spindle.FloodCooling, spindle.FloodCooling
         assert not spindle.MistCooling, spindle.MistCooling
 
@@ -222,7 +222,7 @@ class FabCNC(FabMachine):
     * *Spindle* (FabSpindle): The spindle description.
     * *Controller* (FabController): The Controller used by the CNC machine.
 
-    Contstructor:
+    Constructor:
     * FabCNC("Name", "Position", WorkVolume, Spindle, Table, Controller)
 
     """
@@ -244,7 +244,7 @@ class FabCNC(FabMachine):
     # FabCNC._unit_tests():
     @staticmethod
     def _unit_tests():
-        """Peform FabCNC unit tests."""
+        """Perform FabCNC unit tests."""
         work_volume: Vector = Vector(100.0, 50.0, 30.0)
         spindle: FabSpindle = FabSpindle("R8", 5000, True, True, False)
         table: FabTable = FabTable("TestTable", 100.0, 50.0, 30.0, 4, 10.0, 5.0, 5.0, 10.0, 5.0)
@@ -271,7 +271,7 @@ class FabCNCMill(FabCNC):
     * *Controller* (FabController): The Controller used by the CNC machine.
     * *Kind* (str): Return the string "CNCMill".
 
-    Contstructor:
+    Constructor:
     * FabCNCMill("Name", "Placement", WorkVolume, Spindle, Table, Spindle, Controller)
 
     """
@@ -290,7 +290,7 @@ class FabCNCMill(FabCNC):
     # FabCNCMill._unit_tests():
     @staticmethod
     def _unit_tests():
-        """Peform FabCNCMill unit tests."""
+        """Perform FabCNCMill unit tests."""
         work_volume: Vector = Vector(100.0, 50.0, 30.0)
         spindle: FabSpindle = FabSpindle("R8", 5000, True, True, False)
         controller: FabController = FabController("MyMill", "linuxcnc")
@@ -318,7 +318,7 @@ class FabCNCRouter(FabCNC):
     * *Controller* (FabController): The Controller used by the CNC machine.
     * *Kind* (str): Return the string "CNCRouter".
 
-    Contstructor:
+    Constructor:
     * FabCNCRouter("Name", "Position", WorkVolume, Spindle, Table, Spindle, Controller)
 
     """
@@ -332,7 +332,7 @@ class FabCNCRouter(FabCNC):
     # FabCNCRouter._unit_tests():
     @staticmethod
     def _unit_tests():
-        """Peform FabCNCRouter unit tests."""
+        """Perform FabCNCRouter unit tests."""
         work_volume: Vector = Vector(100.0, 50.0, 30.0)
         spindle: FabSpindle = FabSpindle("R8", 5000, True, True, False)
         controller: FabController = FabController("MyMill", "linuxcnc")

--- a/FabSolids.py
+++ b/FabSolids.py
@@ -307,7 +307,7 @@ class Fab_Operation(object):
 # Fab_Extrude:
 @dataclass(order=True)
 class Fab_Extrude(Fab_Operation):
-    """Fab_Extrude: Prepresents and extrude operation.
+    """Fab_Extrude: Represents and extrude operation.
 
     Attributes:
     * *Name* (str): The operation name.
@@ -1469,7 +1469,7 @@ class FabSolid(FabNode):
         if tracing:
             print(f"{tracing}=>FabSolid.post_produce1('{self.Label}')")
 
-        # Deterimine wether it is posible to *use_cached_step*:
+        # Deterimine whether it is possible to *use_cached_step*:
         use_cached_step: bool = False
         step_path: Path = cast(Path, None)  # Force runtime error if used.
         # This was a shocker.  It turns out that __hash__() methods are not necessarily

--- a/FabTools.py
+++ b/FabTools.py
@@ -148,7 +148,7 @@ class FabShapes(object):
 
     # FabShapes.__post_init__():
     def __post_init__(self) -> None:
-        """Finish intializing FabShapes."""
+        """Finish initializing FabShapes."""
         check_type("FabShapes.Directory", self.Directory, PathFile)
         check_type("FabShapes.Shapes", self.Shapes, Tuple[FabShape, ...])
         check_type("FabShapes.Names", self.Names, Tuple[str, ...])
@@ -234,7 +234,7 @@ class FabAttributes(object):
 
     # FabAttributes.__post_init__():
     def __post_init__(self) -> None:
-        """Finish intializing FabAttributes."""
+        """Finish initializing FabAttributes."""
         check_type("FabAttributes.Values", self.Values, Tuple[Tuple[str, Any], ...])
         check_type("FabAttributes.Names", self.Names, Tuple[str, ...])
 
@@ -316,7 +316,7 @@ class FabBitTemplate(object):
 
     # FabBitTemplate.__post_init__():
     def __post_init__(self) -> None:
-        """Finish initalizing FabBitTemplate."""
+        """Finish initializing FabBitTemplate."""
         check_type("FabBitTemplate.Name", self.Name, str)
         check_type("FabBitTemplate.ExampleName", self.ExampleName, str)
         check_type("FabBitTemplate.ShapeName", self.ShapeName, str)
@@ -720,7 +720,7 @@ class FabBitTemplates(object):
             """Create a FabShape."""
             return FabShape(name, tools_directory / "Shape" / f"{name}.fcstd")
 
-        # Initalize *kwargs* with required values:
+        # Initialize *kwargs* with required values:
         attribute_name: str
         example_name: str = bit_template.ExampleName
         example_value: Union[bool, float, int, str]
@@ -1626,7 +1626,7 @@ class FabLibraries(object):
 
     # FabLibraries.__post_init__():
     def __post_init__(self) -> None:
-        """Finish intializing FabLibriaries."""
+        """Finish initializing FabLibriaries."""
         check_type("FabLibraries.Name", self.Name, str)
         check_type("FabLibraries.LibrariesPath", self.LibrariesPath, PathFile)
         check_type("FabLibraries.Libraries", self.Libraries, Tuple[FabLibrary, ...])
@@ -1697,7 +1697,7 @@ class FabBits(object):
     * *Bits* (Tuple[FabBit, ...]): The associated FabBit's in name sorted order.
     * *Names* (Tuple[str, ...]): The sorted FabBit names.
 
-    Contructor:
+    Constructor:
     * FabBits("Name", BitsPath, Bits, Names)
     """
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ tests: .tests  # Use .tests to remember that tests were run.
 	( grep -n "^!" ${COVER_FILES} | \
 	    grep -v "pragma: no unit test" > /tmp/uncovered_lines ) || true
 	$(COVERAGE) report  # Generate the summary report.
-	$(COVERAGE) erase  # Do not leave around stale coverge information
+	$(COVERAGE) erase  # Do not leave around stale coverage information
 	# rm -f ${COVER_FILES}  # Remove coverage files.
 	touch $@
 

--- a/Patch.py
+++ b/Patch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Patch: A program to patch some FreeCAD files.
 
-The FreeCAD 0.19 Path library has a bug that make it essentailly impossible to support more
+The FreeCAD 0.19 Path library has a bug that make it essentially impossible to support more
 than 1 job from a Python program without using the GUI.  This bug has been fixed in the
-FreeCAD 0.20 version of the library.  The code in this module patchs the files in the
+FreeCAD 0.20 version of the library.  The code in this module patches the files in the
 `PathScripts` directory to fix the problem.
 
 This done in the following steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fab: Python Modelinng and Fabrication.
+# Fab: Python Modeling and Fabrication.
 
 Please see [Fab Documentation](docs/Fab.md)
 

--- a/TarSync.py
+++ b/TarSync.py
@@ -116,7 +116,7 @@ def synchronize_directories(directory_names: Tuple[str, ...],
         If True, the a summary message is printed if for each (possible) synchronization.
         The actual synchronization only occurs if *dry_run* is False.
     * Returns
-      * (Tuple[str, ...]) containing the summar
+      * (Tuple[str, ...]) containing the summary
     """
     # Recursively find all *fcstd_paths* in *directories*:
     fcstd_paths: List[Path] = []

--- a/Test.py
+++ b/Test.py
@@ -46,7 +46,7 @@ class BoxSide(FabSolid):
     * *Contour* (bool):
       Force the side contour to be milled out. (Default: False)
     * *Drill* (bool):
-      Force holes to be drilled. (Defalut: True)
+      Force holes to be drilled. (Default: True)
 
     """
 
@@ -447,7 +447,7 @@ class TestProject(FabProject):
     # TestProject.new():
     @classmethod
     def new(cls, name: str) -> "TestProject":
-        """Return a new TestProject properly initializedd"""
+        """Return a new TestProject properly initialized"""
         test_project = cls(name, cast(FabNode, None))  # Magic to create a root FabProject.
         return test_project
 

--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@
 * [Type Hints and Data Classes](#type-hints-and-data-classes)
 * [Python Modules](#python-modules)
 * [Bearing Block Example](#bearing-block-example)
-* [Addtional Documentation](#additional-documentation)
+* [Additional Documentation](#additional-documentation)
 * [Installation](#installation)
 
 ## Introduction
@@ -208,7 +208,7 @@ The (current) main Python modules are:
   The top level FabNode sub-classes of FabProject, FabDocument, and FabAssembly.
 
 * [FabSolids](docs/FabSolids.md):
-  The Solid creation classs of FabSolid and FabMount.
+  The Solid creation class of FabSolid and FabMount.
 
 * [FabNodes](docs/FabNodes.md):
   The base FabNode class and its associated bounding box FabBox sub-class.
@@ -419,9 +419,9 @@ These installation instructions are currently focused towards the Ubuntu 20.04 L
 
 ## Installation
 
-Installation is always a problematic since there are mulitple operating systems out there
+Installation is always a problematic since there are multiple operating systems out there
 (e.g. Windows, MacOS, Linux).
-In the Linux space, there are multple distributions (e.g. Ubuntu, Red Hat, Arch, etc.)
+In the Linux space, there are multiple distributions (e.g. Ubuntu, Red Hat, Arch, etc.)
 On top of that there various versions of all of these platforms.
 
 Since this code is currently only has one developer,
@@ -476,7 +476,7 @@ These are the steps to follow to install miniconda:
    # All done
    ```
 
-6. Do intitial miniconda activate:
+6. Do initial miniconda activate:
 
    Run:
 
@@ -502,7 +502,7 @@ These are the steps to follow to install miniconda:
    ```
    conda activate
    # `(base) ` should appear
-   conda deactive
+   conda deactivate
    # `(base) ` should disappear
    ```
 
@@ -590,7 +590,7 @@ After minconda is installed do the following:
    >> cadquery.Workplane()
    # Deactivate cadquery-stable
    conda deactivate
-   # miniconda/ directroy is ~4.5G
+   # miniconda/ directory is ~4.5G
    ```
 
 ### Install FreeCad
@@ -652,8 +652,8 @@ but these days both "disk space" and download bandwidth is pretty inexpensive.
     ```
     cd .. # Go to the parent directory of the Fab package
     # One of the following:
-    git clone https://github.com/FreeCAD/FreeCAD.git  # If you do not have Git SSH keys insalled
-    git clone git@github.com:FreeCAD/FreeCAD.git  # If you do have Git SSH keys insalled
+    git clone https://github.com/FreeCAD/FreeCAD.git  # If you do not have Git SSH keys installed
+    git clone git@github.com:FreeCAD/FreeCAD.git  # If you do have Git SSH keys installed
     cd Fab  # Return to Fab Directory
     ls -R ../FreeCAD/src/Mod/Path/Tools  # verify that the Tools directory exists
     ```

--- a/docs/Doc.md
+++ b/docs/Doc.md
@@ -30,18 +30,18 @@ This is a relatively dumb program.  All Python doc strings need to be written in
 * 1 Class: [ModelClass](#doc--modelclass):
   * 1.1 [set_annotations()](#doc----set-annotations): Set the Markdown anchor.
   * 1.2 [summary_lines()](#doc----summary-lines): Return ModelModule summary lines.
-  * 1.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentaion lines.
+  * 1.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentation lines.
 * 2 Class: [ModelDoc](#doc--modeldoc):
   * 2.1 [set_lines()](#doc----set-lines): Set the Lines field of a ModelDoc.
   * 2.2 [set_annotations()](#doc----set-annotations): Set the ModelDoc Anchor and Number attributes.
 * 3 Class: [ModelFunction](#doc--modelfunction):
   * 3.1 [set_annotations()](#doc----set-annotations): Set the markdown annotations.
   * 3.2 [summary_lines()](#doc----summary-lines): Return ModelModule table of contents summary lines.
-  * 3.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentaion lines.
+  * 3.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentation lines.
 * 4 Class: [ModelModule](#doc--modelmodule):
   * 4.1 [set_annotations()](#doc----set-annotations): Set the Markdown anchor.
   * 4.2 [summary_lines()](#doc----summary-lines): Return ModelModule summary lines.
-  * 4.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentaion lines.
+  * 4.3 [documentation_lines()](#doc----documentation-lines): Return the ModelModule documentation lines.
   * 4.4 [generate()](#doc----generate): Generate the markdown and HTML files.
 
 ## <a name="doc--modelclass"></a>1 Class ModelClass:
@@ -68,7 +68,7 @@ Return ModelModule summary lines.
 
 ModelClass.documentation_lines(self, prefix: str) -> Tuple[str, ...]:
 
-Return the ModelModule documentaion lines.
+Return the ModelModule documentation lines.
 
 
 ## <a name="doc--modeldoc"></a>2 Class ModelDoc:
@@ -83,7 +83,7 @@ Attributes:
 * *Anchor* (str):
    The generated Markdown anchor for the documentation element.
    It is of the form "MODULE--CLASS--FUNCTION", where the module/class/function names
-   have underscores converted to hypen.
+   have underscores converted to hyphen.
 * *Number* (str):
    The Table of contents number as a string.  '#" for classes and "#.#" for functions.
 
@@ -140,7 +140,7 @@ Arguments:
 
 ModelFunction.documentation_lines(self, class_name: str, prefix: str) -> Tuple[str, ...]:
 
-Return the ModelModule documentaion lines.
+Return the ModelModule documentation lines.
 Arguments:
 * *prefix* (str): The prefix to use to make the markdown work.
 
@@ -165,7 +165,7 @@ Return ModelModule summary lines.
 
 ModelModule.documentation_lines(self, prefix: str) -> Tuple[str, ...]:
 
-Return the ModelModule documentaion lines.
+Return the ModelModule documentation lines.
 
 ### <a name="doc----generate"></a>4.4 `ModelModule.`generate():
 

--- a/docs/Embed.md
+++ b/docs/Embed.md
@@ -86,7 +86,7 @@ and point the editor at the `.py` file.
 
 Another note is that neither the FreeCAD application nor the FreeCAD console
 (see section immediately below) honor the `PYTHONPATH` environment variable.
-This is deliberate and ensures that is the exact same Python environment is alway used
+This is deliberate and ensures that is the exact same Python environment is always used
 and that it is not effected by other Python applications that require PYTHONPATH
 modifications to properly operate.
 The workaround is add code to explicitly modify `sys.path` as discussed a bit further below.
@@ -195,7 +195,7 @@ The following piece of code will exit the window system when the GUI is up:
      if App.GuiUp:
          Gui.getMainWindow().close()
 
-When the python version changes the followning packages need to be intalled:
+When the python version changes the followning packages need to be installed:
 
 
 

--- a/docs/Fab.md
+++ b/docs/Fab.md
@@ -8,7 +8,7 @@
 * [Type Hints and Data Classes](#type-hints-and-data-classes)
 * [Python Modules](#python-modules)
 * [Bearing Block Example](#bearing-block-example)
-* [Addtional Documentation](#additional-documentation)
+* [Additional Documentation](#additional-documentation)
 * [Installation](#installation)
 
 ## Introduction
@@ -207,7 +207,7 @@ The (current) main Python modules are:
   The top level FabNode sub-classes of FabProject, FabDocument, and FabAssembly.
 
 * [FabSolids](docs/FabSolids.md):
-  The Solid creation classs of FabSolid and FabMount.
+  The Solid creation class of FabSolid and FabMount.
 
 * [FabNodes](docs/FabNodes.md):
   The base FabNode class and its associated bounding box FabBox sub-class.
@@ -418,9 +418,9 @@ These installation instructions are currently focused towards the Ubuntu 20.04 L
 
 ## Installation
 
-Installation is always a problematic since there are mulitple operating systems out there
+Installation is always a problematic since there are multiple operating systems out there
 (e.g. Windows, MacOS, Linux).
-In the Linux space, there are multple distributions (e.g. Ubuntu, Red Hat, Arch, etc.)
+In the Linux space, there are multiple distributions (e.g. Ubuntu, Red Hat, Arch, etc.)
 On top of that there various versions of all of these platforms.
 
 Since this code is currently only has one developer,
@@ -475,7 +475,7 @@ These are the steps to follow to install miniconda:
    # All done
    ```
 
-6. Do intitial miniconda activate:
+6. Do initial miniconda activate:
 
    Run:
 
@@ -501,7 +501,7 @@ These are the steps to follow to install miniconda:
    ```
    conda activate
    # `(base) ` should appear
-   conda deactive
+   conda deactivate
    # `(base) ` should disappear
    ```
 
@@ -589,7 +589,7 @@ After minconda is installed do the following:
    >> cadquery.Workplane()
    # Deactivate cadquery-stable
    conda deactivate
-   # miniconda/ directroy is ~4.5G
+   # miniconda/ directory is ~4.5G
    ```
 
 ### Install FreeCad
@@ -651,8 +651,8 @@ but these days both "disk space" and download bandwidth is pretty inexpensive.
     ```
     cd .. # Go to the parent directory of the Fab package
     # One of the following:
-    git clone https://github.com/FreeCAD/FreeCAD.git  # If you do not have Git SSH keys insalled
-    git clone git@github.com:FreeCAD/FreeCAD.git  # If you do have Git SSH keys insalled
+    git clone https://github.com/FreeCAD/FreeCAD.git  # If you do not have Git SSH keys installed
+    git clone git@github.com:FreeCAD/FreeCAD.git  # If you do have Git SSH keys installed
     cd Fab  # Return to Fab Directory
     ls -R ../FreeCAD/src/Mod/Path/Tools  # verify that the Tools directory exists
     ```

--- a/docs/FabGeometries.md
+++ b/docs/FabGeometries.md
@@ -13,7 +13,7 @@
   * 2.3 [project_to_plane()](#fabgeometries----project-to-plane): Return a new FabGeometry projected onto a plane.
 * 3 Class: [FabPolygon](#fabgeometries--fabpolygon):
   * 3.1 [get_hash()](#fabgeometries----get-hash): Return the FabPolygon Hash.
-  * 3.2 [project_to_plane()](#fabgeometries----project-to-plane): Return nre FabPolygon prejected onto a plane.
+  * 3.2 [project_to_plane()](#fabgeometries----project-to-plane): Return nre FabPolygon projected onto a plane.
   * 3.3 [get_geometries()](#fabgeometries----get-geometries): Return the FabPolygon lines and arcs.
   * 3.4 [produce()](#fabgeometries----produce): Produce the FreeCAD objects needed for FabPolygon.
 * 4 Class: [Fab_Arc](#fabgeometries--fab-arc):
@@ -74,7 +74,7 @@ FabCircle.project_to_plane(self, plane: FabGeometries.Fab_Plane, tracing: str = 
 
 Return a new FabCircle projected onto a plane.
 Arguments:
-* *plane* (Fab_Plane): Plane to proejct to.
+* *plane* (Fab_Plane): Plane to project to.
 
 Returns:
 * (FabCircle): The newly projected FabCicle.
@@ -120,10 +120,10 @@ Return a new FabGeometry projected onto a plane.
 An immutable polygon with rounded corners.
 A FabPolygon is represented as a sequence of corners (i.e. a Vector) where each corner can
 optionally be filleted with a radius.  In order to make it easier to use, a corner can be
-specified as simple Vector or as a tuple that specifes a Vector and a radius.  The radius
+specified as simple Vector or as a tuple that specifies a Vector and a radius.  The radius
 is in millimeters and can be provided as either Python int or float.  When an explicit
 fillet radius is not specified, higher levels in the software stack will typically substitute
-in a deburr radius for external corners and an interal tool radius for internal corners.
+in a deburr radius for external corners and an internal tool radius for internal corners.
 FabPolygon's are frozen and can not be modified after creation.
 
 Example:
@@ -148,7 +148,7 @@ Return the FabPolygon Hash.
 
 FabPolygon.project_to_plane(self, plane: FabGeometries.Fab_Plane, tracing: str = '') -> 'FabPolygon':
 
-Return nre FabPolygon prejected onto a plane.
+Return nre FabPolygon projected onto a plane.
 Arguments:
 * *plane* (Fab_Plane): The plane to project onto.
 

--- a/docs/FabNodes.md
+++ b/docs/FabNodes.md
@@ -28,7 +28,7 @@ Two notable attributes of the FabNode are:
    Up is frequently used in code to access other FabNode's higher in the FabNode tree.
 * *Project* (FabNode):
    The FabNode tree root and is always of type FabProject which is defined in Project package.
-   Due to the Python lanaguage disallowal of circular `import` statements, this is returned
+   Due to the Python language disallowal of circular `import` statements, this is returned
    as type FabNode rather than type FabProject.
 See the FabNode documentation for further attributes.
 
@@ -278,7 +278,7 @@ This typically done, by adding this call immediately after calling super().__pos
 FabNode.probe(self, label: str) -> None:
 
 Perform a probe operation.
-This method can be overriden and called to perform debug probes.
+This method can be overridden and called to perform debug probes.
 
 
 ## <a name="fabnodes--fab-producestate"></a>3 Class Fab_ProduceState:
@@ -288,7 +288,7 @@ Attributes:
 * *StepsDirectory* (Path):
   The path to the directory to store STEP (`.stp`) files into.
 * *Steps* (Fab_Steps):
-  The step file directory managment object.
+  The step file directory management object.
 * *ObjectsTable* (Dict[str, Any]):
   A table of objects that can be accessed via a debugger.
 * *ToolControllersTable*: (Dict[FabToolController, int]):
@@ -296,7 +296,7 @@ Attributes:
 * *OperationIndex* (int):
   An index for the current operation being performed for a mount.
 
-This class is for interal use only:
+This class is for internal use only:
 
 
 ## <a name="fabnodes--fab-steps"></a>4 Class Fab_Steps:
@@ -307,7 +307,7 @@ where  `Name` is the human readable name of the file and `XXXXXXXXXXXXXXXX` is t
 has value associated with the .step file contents.
 
 There are three operations:
-* Fab_Steps(): This is the initalizer.
+* Fab_Steps(): This is the initializer.
 * activate(): This method is used to activate a .stp file for reading and/or writing.
 * flush_stales(): This method is used to remove previous .stp files that are now longer used.
 

--- a/docs/FabProjects.md
+++ b/docs/FabProjects.md
@@ -5,7 +5,7 @@
 * 1 Class: [FabAssembly](#fabprojects--fabassembly):
   * 1.1 [is_assembly()](#fabprojects----is-assembly):  Return True if FabNode is a Fab_Group.
   * 1.2 [to_json()](#fabprojects----to-json): Return FabProject JSON structure.
-  * 1.3 [post_produce1()](#fabprojects----post-produce1): Preform FabAssembly phase1 post production.
+  * 1.3 [post_produce1()](#fabprojects----post-produce1): Perform FabAssembly phase1 post production.
   * 1.4 [post_produce2()](#fabprojects----post-produce2): Perform FabAssembly phase 2 post production.
 * 2 Class: [FabDocument](#fabprojects--fabdocument):
   * 2.1 [to_json()](#fabprojects----to-json): Return FabProject JSON structure.
@@ -43,7 +43,7 @@ Return FabProject JSON structure.
 
 FabAssembly.post_produce1(self, produce_state: FabNodes.Fab_ProduceState, tracing: str = '') -> None:
 
-Preform FabAssembly phase1 post production.
+Perform FabAssembly phase1 post production.
 
 ### <a name="fabprojects----post-produce2"></a>1.4 `FabAssembly.`post_produce2():
 

--- a/docs/FabShops.md
+++ b/docs/FabShops.md
@@ -34,7 +34,7 @@ Attributes:
 * *Spindle* (FabSpindle): The spindle description.
 * *Controller* (FabController): The Controller used by the CNC machine.
 
-Contstructor:
+Constructor:
 * FabCNC("Name", "Position", WorkVolume, Spindle, Table, Controller)
 
 
@@ -50,7 +50,7 @@ Attributes:
 * *Controller* (FabController): The Controller used by the CNC machine.
 * *Kind* (str): Return the string "CNCMill".
 
-Contstructor:
+Constructor:
 * FabCNCMill("Name", "Placement", WorkVolume, Spindle, Table, Spindle, Controller)
 
 
@@ -66,7 +66,7 @@ Attributes:
 * *Controller* (FabController): The Controller used by the CNC machine.
 * *Kind* (str): Return the string "CNCRouter".
 
-Contstructor:
+Constructor:
 * FabCNCRouter("Name", "Position", WorkVolume, Spindle, Table, Spindle, Controller)
 
 
@@ -154,12 +154,12 @@ Represents a machine tool spindle.
 Attributes:
 * *Type* (str): Spindle Type (e.g. "R8", "Cat40", etc.)
 * *Speed* (int): Maximum spindle speed in rotations per minute.
-* *Reversable* (bool): True if spindle can be reversed.
+* *Reversible* (bool): True if spindle can be reversed.
 * *FloodCooling* (bool): True if flood cooling is available.
 * *MistCooling* (bool): True if mist coooling is available.
 
 Constructor:
-* FabSpindle("Type", Speed, Reversable, FloodCooling, MistCooling)
+* FabSpindle("Type", Speed, Reversible, FloodCooling, MistCooling)
 
 
 ## <a name="fabshops--fabtable"></a>9 Class FabTable:

--- a/docs/FabSolids.md
+++ b/docs/FabSolids.md
@@ -225,7 +225,7 @@ Wrap some stock material around a FabBox.
 
 ## <a name="fabsolids--fab-extrude"></a>4 Class Fab_Extrude:
 
-Prepresents and extrude operation.
+Represents and extrude operation.
 Attributes:
 * *Name* (str): The operation name.
 * *Geometry* (Union[FabGeometry, Tuple[FabGeometry, ...]):

--- a/docs/FabTools.md
+++ b/docs/FabTools.md
@@ -185,7 +185,7 @@ Attributes:
 * *Bits* (Tuple[FabBit, ...]): The associated FabBit's in name sorted order.
 * *Names* (Tuple[str, ...]): The sorted FabBit names.
 
-Contructor:
+Constructor:
 * FabBits("Name", BitsPath, Bits, Names)
 
 ### <a name="fabtools----lookup"></a>7.1 `FabBits.`lookup():

--- a/docs/Geometry.md
+++ b/docs/Geometry.md
@@ -13,7 +13,7 @@
   * 2.3 [project_to_plane()](#geometry----project-to-plane): Return a new FabGeometry projected onto a plane.
 * 3 Class: [FabPolygon](#geometry--fabpolygon):
   * 3.1 [get_hash()](#geometry----get-hash): Return the FabPolygon Hash.
-  * 3.2 [project_to_plane()](#geometry----project-to-plane): Return nre FabPolygon prejected onto a plane.
+  * 3.2 [project_to_plane()](#geometry----project-to-plane): Return nre FabPolygon projected onto a plane.
   * 3.3 [get_geometries()](#geometry----get-geometries): Return the FabPolygon lines and arcs.
   * 3.4 [produce()](#geometry----produce): Produce the FreeCAD objects needed for FabPolygon.
 * 4 Class: [Fab_Arc](#geometry--fab-arc):
@@ -74,7 +74,7 @@ FabCircle.project_to_plane(self, plane: Geometry.Fab_Plane, tracing: str = '') -
 
 Return a new FabCircle projected onto a plane.
 Arguments:
-* *plane* (Fab_Plane): Plane to proejct to.
+* *plane* (Fab_Plane): Plane to project to.
 
 Returns:
 * (FabCircle): The newly projected FabCicle.
@@ -120,10 +120,10 @@ Return a new FabGeometry projected onto a plane.
 An immutable polygon with rounded corners.
 A FabPolygon is represented as a sequence of corners (i.e. a Vector) where each corner can
 optionally be filleted with a radius.  In order to make it easier to use, a corner can be
-specified as simple Vector or as a tuple that specifes a Vector and a radius.  The radius
+specified as simple Vector or as a tuple that specifies a Vector and a radius.  The radius
 is in millimeters and can be provided as either Python int or float.  When an explicit
 fillet radius is not specified, higher levels in the software stack will typically substitute
-in a deburr radius for external corners and an interal tool radius for internal corners.
+in a deburr radius for external corners and an internal tool radius for internal corners.
 FabPolygon's are frozen and can not be modified after creation.
 
 Example:
@@ -148,7 +148,7 @@ Return the FabPolygon Hash.
 
 FabPolygon.project_to_plane(self, plane: Geometry.Fab_Plane, tracing: str = '') -> 'FabPolygon':
 
-Return nre FabPolygon prejected onto a plane.
+Return nre FabPolygon projected onto a plane.
 Arguments:
 * *plane* (Fab_Plane): The plane to project onto.
 

--- a/docs/Node.md
+++ b/docs/Node.md
@@ -28,7 +28,7 @@ Two notable attributes of the FabNode are:
    Up is frequently used in code to access other FabNode's higher in the FabNode tree.
 * *Project* (FabNode):
    The FabNode tree root and is always of type FabProject which is defined in Project package.
-   Due to the Python lanaguage disallowal of circular `import` statements, this is returned
+   Due to the Python language disallowal of circular `import` statements, this is returned
    as type FabNode rather than type FabProject.
 See the FabNode documentation for further attributes.
 
@@ -278,7 +278,7 @@ This typically done, by adding this call immediately after calling super().__pos
 FabNode.probe(self, label: str) -> None:
 
 Perform a probe operation.
-This method can be overriden and called to perform debug probes.
+This method can be overridden and called to perform debug probes.
 
 
 ## <a name="node--fab-producestate"></a>3 Class Fab_ProduceState:
@@ -288,7 +288,7 @@ Attributes:
 * *StepsDirectory* (Path):
   The path to the directory to store STEP (`.stp`) files into.
 * *Steps* (Fab_Steps):
-  The step file directory managment object.
+  The step file directory management object.
 * *ObjectsTable* (Dict[str, Any]):
   A table of objects that can be accessed via a debugger.
 * *ToolControllersTable*: (Dict[FabToolController, int]):
@@ -296,7 +296,7 @@ Attributes:
 * *OperationIndex* (int):
   An index for the current operation being performed for a mount.
 
-This class is for interal use only:
+This class is for internal use only:
 
 
 ## <a name="node--fab-steps"></a>4 Class Fab_Steps:
@@ -307,7 +307,7 @@ where  `Name` is the human readable name of the file and `XXXXXXXXXXXXXXXX` is t
 has value associated with the .step file contents.
 
 There are three operations:
-* Fab_Steps(): This is the initalizer.
+* Fab_Steps(): This is the initializer.
 * activate(): This method is used to activate a .stp file for reading and/or writing.
 * flush_stales(): This method is used to remove previous .stp files that are now longer used.
 

--- a/docs/Solid.md
+++ b/docs/Solid.md
@@ -225,7 +225,7 @@ Wrap some stock material around a FabBox.
 
 ## <a name="solid--fab-extrude"></a>4 Class Fab_Extrude:
 
-Prepresents and extrude operation.
+Represents and extrude operation.
 Attributes:
 * *Name* (str): The operation name.
 * *Geometry* (Union[FabGeometry, Tuple[FabGeometry, ...]):

--- a/docs/Test.md
+++ b/docs/Test.md
@@ -78,7 +78,7 @@ Additional Constructor Attributes:
 * *Contour* (bool):
   Force the side contour to be milled out. (Default: False)
 * *Drill* (bool):
-  Force holes to be drilled. (Defalut: True)
+  Force holes to be drilled. (Default: True)
 
 ### <a name="test----produce"></a>2.1 `BoxSide.`produce():
 

--- a/fabcnc.sh
+++ b/fabcnc.sh
@@ -13,7 +13,7 @@
 #     -c|--cnc specifies the CNC mode.
 #     FAB.json specifies the JSON file to use.
 #
-# It is further assumed that the requried STEP files are in the same directory as the JSON file.
+# It is further assumed that the required STEP files are in the same directory as the JSON file.
 
 # Get the directory that contains this script file:
 # [Get Script Directory](https://dirask.com/posts/Bash-get-current-script-directory-path-1X9E8D)


### PR DESCRIPTION
Found via `codespell -q 3 -L te,tne`